### PR TITLE
Fix openended code area in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ app.add_plugins(IosSafeAreaPlugin);
 fn bevy_system(safe_area: Res<IosSafeAreaResource>) {
     let safe_area_top = safe_area.top();
 }
+```
 
 ## Our Other Crates
 


### PR DESCRIPTION
The code area of the usage example seems to be missing the closing 'tag'.